### PR TITLE
chore: add automated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - name: Verify dist is up to date
+        run: |
+          if [ -n "$(git status --porcelain dist/)" ]; then
+            echo "Error: dist/ is out of date. Run 'npm run build' and commit before tagging."
+            exit 1
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+
+      - name: Update major version tag
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          MAJOR=${VERSION%%.*}
+          git tag -fa $MAJOR -m "Update $MAJOR tag to $VERSION"
+          git push origin $MAJOR --force


### PR DESCRIPTION
Automates the release process on version tags.

**Trigger:** Push tag matching `v*.*.*`

**Steps:**
1. Build and verify dist is up to date
2. Create GitHub Release with auto-generated notes
3. Update major version tag (v1 → v1.x.x)

**Usage after merge:**
```bash
npm version patch
git push origin main --tags
```

Based on [GitHub's action-versioning best practices](https://github.com/actions/toolkit/blob/main/docs/action-versioning.md).