### PR TITLE
fix: release workflow and docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Update major version tag
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           VERSION=${GITHUB_REF#refs/tags/}
           MAJOR=${VERSION%%.*}
           git tag -fa $MAJOR -m "Update $MAJOR tag to $VERSION"

--- a/README.md
+++ b/README.md
@@ -268,39 +268,24 @@ Always rebuild before releasing to ensure the dist folder is up to date:
 npm run build
 ```
 
-### 2. Commit and Update Version
+### 2. Commit and Merge
 
 ```bash
-git add dist/
-git commit -m "build: bundle for release"
-npm version patch  # or minor/major (this creates a commit and tag)
+# Update version in package.json manually
+git add package.json dist/
+git commit -m "1.x.x"
+# Create PR and merge to main
 ```
 
-### 3. Create and Push Tags
+### 3. Tag the Release
 
 ```bash
-# Push the version tag created by npm version
-git push origin main --tags
-
-# Create/update the major version tag (allows users to use @v1)
-git tag -f v1
-git push origin v1 --force
+git checkout main && git pull
+git tag v1.x.x
+git push origin v1.x.x
 ```
 
-### 4. Create GitHub Release
-
-1. Go to [Releases](https://github.com/PostHog/posthog-github-action/releases)
-2. Click "Draft a new release"
-3. Select the version tag (e.g., `v1.0.0`)
-4. Add release title and notes
-5. Click "Publish release"
-
-### 5. Publish to GitHub Marketplace
-
-1. When creating/editing the release, check "Publish this Action to the GitHub Marketplace"
-2. Select the primary category (e.g., "Continuous integration")
-3. Ensure `action.yml` has all required fields (`name`, `description`, `author`)
-4. Publish the release
+The release workflow creates the GitHub Release and updates the `v1` tag automatically.
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "posthog-github-action",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "posthog-github-action",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-github-action",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Send events to PostHog from GitHub Actions",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Add git user config for tag updates (was failing with 'empty ident name')
- Update release docs for branch-protection-compatible workflow
- Bump version to 1.1.0