### PR TITLE
chore: update to node 24 and bump action versions to latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '24'
 
       - run: npm ci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           generate_release_notes: true
 

--- a/action.yml
+++ b/action.yml
@@ -37,5 +37,5 @@ inputs:
     description: "Job name to check for workflow status (e.g., 'Django Tests Pass'). Captures that job's conclusion."
     required: false
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"


### PR DESCRIPTION
## Changes

- Updated the GitHub Action runtime from `node20` to `node24` in `action.yml`
- Bumped workflow action versions in `.github/workflows/release.yml`:
  - `actions/checkout`: v4 → v5
  - `actions/setup-node`: v4 → v5
  - Node version for build: 20 → 24
- Pinned `softprops/action-gh-release` to SHA (`153bb8e0`) for `ensure-pinned-actions` compliance, with `# v2` comment for readability